### PR TITLE
docs: comparative analysis of stablecoin depeg events (Closes #3)

### DIFF
--- a/depeg_analysis.md
+++ b/depeg_analysis.md
@@ -1,0 +1,16 @@
+# Analysis of Significant Stablecoin Depeg Events (2021-2023)
+
+## 1. TerraUSD (UST) - May 2022
+- **Context**: TerraUSD (UST), once the leading algorithmic stablecoin, lost its $1.00 peg in May 2022 and rapidly crashed to near zero.
+- **Primary Reason**: **Algorithmic Failure & Death Spiral**. UST relied on an arbitrage mechanism with its sister token, LUNA. When massive sell-offs occurred - fueled by capital flight from the Anchor Protocol's unsustainable 20% yields - the system minted LUNA to stabilize UST. This triggered a hyper-inflationary feedback loop, resulting in a total collapse of both tokens.
+- **Systemic Impact**: Wiped out approximately $45-60 billion in ecosystem value. It triggered a massive market-wide contagion, leading to the insolvency of high-profile crypto firms such as **Three Arrows Capital (3AC)**, **Celsius Network**, and **Voyager Digital**.
+
+## 2. USD Coin (USDC) - March 2023
+- **Context**: In March 2023, USDC depegged to a low of approximately $0.88 following the rapid collapse of Silicon Valley Bank (SVB).
+- **Primary Reason**: **Counterparty Reserve Risk**. Circle, the issuer of USDC, confirmed that $3.3 billion of its cash reserves were held at the defunct SVB. This revelation sparked fears that the stablecoin was under-collateralized, triggering a massive wave of redemptions.
+- **Systemic Impact**: Temporarily depegged other stablecoins like **DAI** (which relied on USDC as a primary reserve asset). The peg was restored once the U.S. government stepped in to guarantee all SVB deposits, proving the stablecoin's dependence on traditional banking system health.
+
+## 3. Iron Finance (IRON) - June 2021
+- **Context**: IRON was a 'partially collateralized' stablecoin on the Polygon network. In June 2021, its value crashed to below $0.75 as its collateral token, TITAN, fell to zero.
+- **Primary Reason**: **Algorithmic Bank Run**. IRON was backed 75% by USDC and 25% by TITAN. When large TITAN holders began selling, the protocol minted more TITAN to keep IRON at $1. This created a hyper-inflationary supply of TITAN, leading to a complete loss of value in the collateral and the subsequent depegging of IRON.
+- **Systemic Impact**: Notable as the first major DeFi 'death spiral.' While it primarily affected the Polygon ecosystem and private investors, it served as a precursor and critical case study for the risks inherent in algorithmic pegging mechanisms.


### PR DESCRIPTION
Documented analysis of significant stablecoin depeg events from 2021 to 2023, including TerraUSD, USD Coin, and Iron Finance.