### PR TITLE
Add agent-to-agent payment landscape brief

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Published research notes, analysis, and briefs from the kcolbchain research coll
 | Brief | Date | Scope |
 |-------|------|-------|
 | [Stablecoin Depeg Events](depeg_analysis.md) | May 2026 | UST, USDC, BUSD, TUSD, USDe, and BIS/NBER run-risk framing |
+| [Agent-to-Agent Payment Protocols in 2026](briefs/agent-to-agent-payment-landscape-2026.md) | Jun 2026 | x402, MPP, AP2, Circle Nanopayments, and Switchboard comparison |
 | [MEV on L2 Rollups](briefs/mev-l2-rollups.md) | May 2026 | Sequencer extraction, shared sequencers, SUAVE, Timeboost, OP Stack revenue |
 | [Q2 2026 Research Brief](briefs/2026-Q2-research-brief.md) | Apr 2026 | L2 scaling, payments, stablecoins, DeFi, MEV, RWAs |
 | [LABELTON: A rights primitive for music on-chain](briefs/labelton-music-rights-primitive.md) | May 2026 | Music rights on-chain, ISRC/UPC/ISWC anchoring, wallet-sovereign mint at master generation, Muzix DAO / CR8 chain stratification |

--- a/briefs/agent-to-agent-payment-landscape-2026.md
+++ b/briefs/agent-to-agent-payment-landscape-2026.md
@@ -1,69 +1,226 @@
-# Navigating the Machine Ledger: A 2026 Survey of Agent-to-Agent Payment Protocols
+# Agent-to-Agent Payment Protocols in 2026
 
 ## Abstract
-Agent-to-agent commerce is moving from theory to implementation, but the ecosystem is still fragmented across several overlapping payment rails. This brief compares five current approaches: Coinbase’s x402, Stripe’s machine payments / MPP, Google’s AP2 proposal, Circle’s Agent Nanopayments, and kcolbchain’s Switchboard substrate. The main finding is simple: there is no single winner yet. x402 is the cleanest HTTP-native rail for pay-per-request access, Stripe’s machine payments are the best fit for merchants that want fiat settlement and existing Stripe accounting, Circle is pushing sub-cent USDC micropayments for high-frequency flows, AP2 is trying to define an interoperable trust and liability layer, and Switchboard is the most explicit open-source substrate for agent-to-agent settlement. The practical near-term market is not “one protocol to rule them all” but a layered stack where discovery, authorization, settlement, and wallet policy are separated.
+
+Agent-to-agent payments are splitting into three layers: HTTP-native settlement,
+agent authorization, and high-frequency stablecoin clearing. x402 and the
+Machine Payments Protocol (MPP) make paid resources callable over ordinary HTTP
+requests. AP2 focuses on signed mandates, consent, and dispute evidence for
+autonomous commerce. Circle Nanopayments attacks the cost problem by batching
+USDC settlement through Circle Gateway. kcolbchain Switchboard is best read as a
+developer substrate that combines x402-style HTTP gates, on-chain escrow, gas
+budgets, nonce safety, and compact agent-to-agent wire formats. The main finding
+is that these systems are more complementary than mutually exclusive: x402 and
+MPP meter access, AP2 governs authorization, Circle lowers settlement cost, and
+Switchboard composes these primitives into agent operations.
 
 ## Context
-Agentic commerce creates a payments problem that ordinary web billing flows were never built to solve. Autonomous agents need to discover price, prove authority, authorize spend, and settle quickly enough to avoid breaking the interaction loop. The current landscape shows two clear design patterns:
 
-1. **HTTP-native payment challenges** that let a server demand payment before serving a resource.
-2. **Agent-wallet/payment substrates** that focus on permissions, settlement, and microtransaction routing.
+Autonomous agents can already discover APIs, call tools, and delegate work, but
+most still cannot pay cleanly at runtime. Traditional web billing assumes a
+human creates an account, stores a card, buys credits, and manages API keys.
+That model is too slow and too stateful for agents that need to buy one model
+inference, one dataset row, one crawler result, or one peer-agent task.
 
-The result is a market with overlapping but not identical goals. Some protocols optimize for pay-per-request APIs, some for corporate merchant settlement, some for stablecoin micropayments, and some for open multi-hop agent settlement.
+The dormant HTTP `402 Payment Required` status code has become the shared
+coordination point. x402 describes an HTTP flow in which a resource server
+returns payment requirements, the client retries with a signed payment payload,
+and a facilitator verifies or settles the payment before the protected resource
+is returned ([Coinbase x402 docs](https://docs.cdp.coinbase.com/x402/welcome)).
+MPP uses the same basic idea but is organized around a broader payment
+authentication and billing surface, including payment methods such as card,
+EVM, Lightning, Solana, Stellar, Stripe, and Tempo in the public specification
+index ([paymentauth.org](https://paymentauth.org/)). AP2 solves a different
+problem: how a shopping agent proves that it is authorized to buy something,
+especially when the user is no longer present
+([AP2 specification](https://ap2-protocol.org/ap2/specification/)).
+
+These protocols matter now because agent workloads make per-request pricing
+useful again. However, per-request pricing only works if the cost of payment is
+lower than the service being purchased. Circle Nanopayments targets that
+constraint directly by aggregating offchain USDC authorizations and settling
+net positions in bulk through Circle Gateway
+([Circle Nanopayments docs](https://developers.circle.com/gateway/nanopayments)).
 
 ## Key Findings
-- **x402 is the strongest HTTP-native default** for paid APIs and machine access. Coinbase’s docs describe it as an open protocol that revives HTTP 402 and allows clients, including AI agents, to pay programmatically without accounts or complex authentication.
-- **Stripe machine payments / MPP are the best enterprise bridge** because they let agents pay programmatically while routing value into Stripe’s existing balance and reporting stack, with support for both x402 and MPP across listed networks.
-- **AP2 is the most important interoperability proposal**, but it is still a proposal. Its value is in standardizing how agents prove authority and liability across A2A, MCP, and UCP-style systems.
-- **Circle Agent Nanopayments are the most explicit sub-cent USDC rail** for high-frequency agent commerce. Circle says the system is built on Gateway Nanopayments and batches small x402-compatible payments into onchain settlement.
-- **Switchboard is the most open-ended agent-to-agent substrate** in this set. Its repo frames the project as programmable payments for AI agents over HTTP/402, escrow, multi-party micropayments, and stablecoin rails.
+
+- x402 is the simplest resource-access rail: an HTTP server can make a route
+  payable, and a client can attach a signed payment in the retry request. Its
+  strength is low integration friction; its weakness is that business intent,
+  delegated consent, and disputes are mostly outside the core payment flow.
+- MPP is the broadest billing rail: it standardizes machine payment
+  authentication across multiple payment methods and adds higher-level
+  lifecycle concepts such as sessions, subscriptions, receipts, and typed
+  payment hooks ([MPP subscriptions](https://mpp.dev/blog/subscriptions),
+  [MPP payment hooks](https://mpp.dev/blog/payment-hooks)).
+- AP2 is not a settlement rail. It is an authorization and evidence layer built
+  around Checkout Mandates, Payment Mandates, Receipts, and role-specific
+  verification duties. This makes it useful for commerce workflows where a
+  later dispute may ask what the user approved and what the agent actually did.
+- Circle Nanopayments is the clearest 2026 answer to sub-cent economics:
+  buyers sign offchain authorizations, sellers verify instantly, and Gateway
+  batches on-chain settlement. Circle states that transfers can be as small as
+  $0.000001 USDC and are available on testnet for Gateway-supported EVM chains
+  ([Circle blog, 2026-03-10](https://www.circle.com/blog/circle-nanopayments-launches-on-testnet-as-the-core-primitive-for-agentic-economic-activity)).
+- kcolbchain Switchboard fits the operations layer: it combines x402
+  middleware, AgentEscrow, gas-budget controls, nonce management, and a ZAP
+  binary wire for high-volume agent-to-agent messages
+  ([kcolbchain/switchboard](https://github.com/kcolbchain/switchboard)).
 
 ## Analysis
 
-### 1. x402: the cleanest HTTP payment challenge
-x402 is the best fit when the problem is “charge per request” or “unlock a resource on demand.” Its design is deliberately simple: the server returns HTTP 402 with payment instructions, the client signs a payment payload, and the server verifies settlement through a facilitator. Coinbase positions it for APIs, paywalls, tool calls, and agent-driven access.
+### Comparison table
 
-That simplicity matters. It keeps the payment exchange close to normal web semantics instead of forcing a separate billing or checkout flow. For builders, x402 is attractive because it minimizes integration friction and keeps the payment handshake close to request/response logic.
+| Protocol / rail | Primary layer | Gas cost | Latency | Chain support | 2026 maturity |
+|---|---|---:|---|---|---|
+| x402 | HTTP payment for resources | Depends on scheme and facilitator; no x402 protocol fee, but settlement may touch chain | One extra 402/retry round trip plus verification; settlement latency depends on facilitator policy | Network and token agnostic by design; reference packages include EVM, SVM, and Stellar support | Live ecosystem with public docs, SDKs, and an LF Projects foundation site; still early for disputes and compliance workflows |
+| MPP | Machine payment authentication and billing | Depends on selected method: card, Stripe, Tempo, EVM, Lightning, Solana, Stellar, or other specs | Request-path challenge and credential flow; sessions and subscriptions reduce repeated signing | Multi-rail by specification, including web2 and crypto payment methods | Young but moving quickly; public specs, services, SDKs, subscriptions, and observability hooks are visible |
+| AP2 | Agent authorization and dispute evidence | Not applicable; AP2 delegates settlement to payment processors or networks | Higher ceremony: mandates, credential provider checks, merchant checks, and receipts | Rail agnostic; designed for commerce protocols rather than one chain | v0.2 specification; strongest as a governance and verification model, not a minimal API-metering primitive |
+| Circle Nanopayments | USDC nanopayment clearing | Zero per-payment gas for buyer/seller in Gateway flow; batch settlement happens later | Seller receives instant confirmation after signature validation; on-chain settlement is delayed/batched | Gateway-supported EVM chains in testnet; Circle documentation says the current list should be checked dynamically | Developer testnet/product docs; strong for USDC-specific high-frequency payments, less general than x402 or MPP |
+| Switchboard | Agent payment substrate and tooling | Depends on chosen rail; escrow and direct chain use require gas, but gas budgets and nonce management bound operational risk | Depends on module: x402 middleware is HTTP-native, AgentEscrow waits on chain, ZAP targets hot-path A2A transport | EVM-oriented today, with Base/Sepolia examples and alignment with x402, MPP tracking, and Lux ZAP | Early open-source implementation, useful for builders who want escrow, safety controls, and rail comparison in one stack |
 
-### 2. Stripe machine payments / MPP: the enterprise path
-Stripe’s machine payments docs frame the product around agents paying for resources programmatically, with crypto payments landing in Stripe balance. Stripe also lists support for x402 on Base and MPP on Solana and Tempo, which makes the Stripe stack less like a single protocol and more like a merchant-facing settlement layer across rails.
+### x402: HTTP access as the payment boundary
 
-That makes Stripe the strongest choice for companies that want agentic payments without abandoning their existing Stripe operational stack. It is less “pure protocol” than x402, but it is much easier to operationalize for merchants that care about balance settlement, refunds, reporting, and existing finance workflows.
+x402's core design is intentionally small. A resource server returns `402
+Payment Required` when the request lacks payment. The client selects payment
+requirements, creates a payment payload for the chosen scheme and network, and
+retries with the signed payload. The server verifies locally or through a
+facilitator, performs the work, and optionally asks the facilitator to settle
+the payment ([coinbase/x402 README](https://github.com/coinbase/x402)).
 
-### 3. AP2: the trust and liability layer
-AP2 is best understood as an open interoperability proposal, not a live settlement rail. The documentation frames the core problem as trust: existing payments infrastructure was not built for autonomous agents acting on behalf of users, and the result is ambiguity around authority and liability. AP2’s value is not in replacing every payment protocol but in defining how agent payments should be validated across broader agent ecosystems.
+This design is strong for paid APIs, paid files, data queries, model
+inference, pay-per-page content, and machine-usable services. The resource
+itself defines what is being bought. x402 also benefits from a clear ecosystem
+message: it is HTTP-native, permissionless, neutral, and resource-server
+friendly. The public x402 site showed meaningful last-30-day transaction,
+volume, buyer, and seller metrics when accessed for this brief, which suggests
+that adoption is past the toy-only stage ([x402.org](https://www.x402.org/),
+accessed 2026-06-06).
 
-In practice, AP2 looks more like a protocol layer that could sit above or alongside x402, MPP, or similar systems. If x402 and MPP answer “how does payment happen?”, AP2 is trying to answer “how do we safely authorize and interpret agent-led payment intent?”
+The weakness is that x402 is not a full commerce governance model. It can prove
+that a payment was attached to a request; it does not, by itself, solve product
+substitution, refund rules, user delegation, merchant inventory integrity, or
+the evidence package for "my agent bought the wrong thing." For high-value
+autonomous purchases, x402 likely needs AP2-style mandates or merchant-specific
+policy layers above it.
 
-### 4. Circle Agent Nanopayments: sub-cent stablecoin settlement
-Circle’s Agent Nanopayments target the niche where per-action fees are too small to justify ordinary onchain settlement. Circle says the system is built on Gateway Nanopayments, supports x402-compatible services, and batches many tiny payments into a single onchain settlement. That makes it suitable for high-frequency flows like metered API usage, streaming services, and small-value tool calls.
+### MPP: broader machine billing, not just one-shot payments
 
-Circle’s advantage is clear: sub-cent USDC is a strong story for machine-scale commerce. The tradeoff is that it is still an ecosystem-specific rail, so builders need to decide whether they want Circle’s stack or a more neutral protocol like x402.
+MPP should not be treated as merely "x402 by Stripe and Tempo." Its public
+surface is broader: the specification index separates the Payment HTTP
+authentication scheme, charge methods, sessions, discovery, and JSON-RPC/MCP
+transport ([Machine Payments Protocol specifications](https://paymentauth.org/)).
+The MPP homepage describes an open protocol for machine-to-machine payments in
+the same HTTP call and credits Tempo and Stripe as designers
+([mpp.dev](https://mpp.dev/)).
 
-### 5. Switchboard: open-source agent settlement substrate
-Switchboard is the most product-agnostic and community-driven project in the set. The repo describes it as programmable payments for AI agents, with support for HTTP/402, on-chain escrow, multi-party micropayments, and stablecoin rails. That makes it useful as an architectural substrate rather than just a payment endpoint.
+MPP's biggest advantage is lifecycle coverage. One-time charges are useful for
+fixed-price resources, but agent work often includes streamed tokens, bytes,
+or long-running tool calls. MPP sessions fit variable usage, while
+subscriptions allow recurring access without forcing the client to sign every
+request. MPP's payment hooks also show production awareness: systems need to
+observe challenges, failures, receipts, method names, amounts, currencies, and
+support references without rewriting the payment handler.
 
-The advantage of this framing is flexibility. Switchboard can sit under different payment flows instead of forcing one canonical payment path. The downside is that it does not provide the same turnkey merchant or accounting story as Stripe, nor the narrow HTTP challenge simplicity of x402. It is a substrate, not a complete payments product.
+The tradeoff is complexity. A broad multi-rail spec has to normalize very
+different settlement semantics. Card, Stripe, Lightning, EVM, Solana, Stellar,
+and Tempo payments do not share the same finality, refund, compliance, or key
+management properties. MPP's architecture is promising for commercial APIs and
+MCP servers, but interoperability will depend on how consistently clients,
+wallets, and service directories implement the same challenge and credential
+behavior.
 
-## Comparison Matrix
-| Protocol | Primary strength | Best fit | Maturity signal |
-| --- | --- | --- | --- |
-| x402 | HTTP-native paywall and API payments | Per-request APIs, content paywalls, agent access | Open docs and active Coinbase development |
-| Stripe machine payments / MPP | Merchant settlement and accounting integration | Enterprises that want Stripe balance / reporting | Stripe docs and productized integration |
-| AP2 | Interoperability and trust framing | Cross-platform agent payment authorization | Open protocol proposal |
-| Circle Agent Nanopayments | Sub-cent USDC batching | High-frequency machine-to-machine commerce | Circle docs and product rollout |
-| Switchboard | Open-source programmable agent settlement | Agent-to-agent work settlement and experimentation | Active open-source repo |
+### AP2: mandates for consent and dispute evidence
+
+AP2 operates at the trust layer rather than the payment rail. It defines five
+roles: Shopping Agent, Credential Provider, Merchant, Merchant Payment
+Processor, and Trusted Surface. Its core objects are Checkout Mandates and
+Payment Mandates, linked to receipts. The protocol distinguishes human-present
+flows, where a user approves a closed checkout, from human-not-present flows,
+where the user delegates constraints and the agent later signs closed mandates
+within those constraints ([AP2 flows](https://ap2-protocol.org/ap2/flows/)).
+
+This makes AP2 heavier than x402 or MPP for a simple paid API call. That is a
+feature, not a bug, for autonomous shopping or business procurement. The
+merchant needs to know the checkout matches what it created. The payment
+processor needs to know the payment mandate binds to that checkout. If there is
+a dispute, the receipts and mandates should explain what the agent was allowed
+to do.
+
+The open question is adoption. AP2 deliberately leaves commerce APIs and some
+selection mechanics outside the core spec. That keeps AP2 rail agnostic, but it
+means implementers still need payment rails, credential providers, merchant
+integration, and wallet/trusted-surface UX. AP2 may become the authorization
+layer above x402, MPP, cards, stablecoins, and bank payments, but it is not the
+fastest path for a developer who only wants to charge $0.001 per API call.
+
+### Circle Nanopayments: making tiny USDC payments economical
+
+Circle Nanopayments addresses a narrower and very important bottleneck:
+transaction cost. The Circle Gateway design lets buyers sign offchain
+authorizations, lets sellers verify and serve immediately, and batches final
+settlement later. Circle's documentation frames this as gas-free USDC
+nanopayments down to $0.000001 and explicitly connects the flow to x402-style
+HTTP `402 Payment Required` resources.
+
+This is well matched to agent workloads where a single user goal may generate
+hundreds or thousands of micro-purchases: search, crawl, data enrichment,
+memory writes, model routing, or peer-agent calls. The weakness is scope.
+Nanopayments are USDC and Circle Gateway centric. Builders get cost compression
+and a familiar regulated issuer, but they also inherit Gateway availability,
+supported-chain limits, and Circle's product surface. It complements x402
+rather than replacing it: x402 can define the HTTP handshake, while Circle can
+make the settlement economics work for sub-cent values.
+
+### Switchboard: composable agent-payment operations
+
+Switchboard is not trying to be only a standard. It is a working substrate for
+builders who need multiple rails in one agent stack. Its README ships an x402
+middleware, AgentEscrow, a payment client, gas-budget controls, nonce safety,
+and a ZAP binary wire for compact high-volume agent-to-agent messages. That
+combination is important because the operational failures of autonomous
+payments are often outside the happy-path payment protocol: runaway loops,
+nonce reuse, reorgs, escrow disputes, and oversized wire formats.
+
+Switchboard's strength is composition. It can expose an x402-style paid route,
+settle more complex work through escrow, cap an agent's spend rate, and compare
+external rails in one explorer. Its weakness is maturity and reach. x402, MPP,
+AP2, and Circle each have larger ecosystem sponsors or more formal standards
+positioning. Switchboard should therefore position itself as the pragmatic
+implementation and safety layer: the place where agent payment protocols become
+usable in tests, demos, and early production systems.
 
 ## Risks and Open Questions
-- **Fragmentation risk:** these systems overlap, but none is yet the universal default.
-- **Authority and liability:** AP2 highlights a real gap, but the industry still needs clearer answers on who is liable when an agent spends.
-- **Merchant adoption:** x402 and Circle are useful technically, but merchants still need operational reasons to support another rail.
-- **Wallet policy and safety:** agent wallets need guardrails, rate limits, and scoped authority or they become a liability fast.
-- **Interoperability:** the market likely needs bridges between protocol layers instead of a winner-take-all format.
+
+- **Fragmentation risk:** x402, MPP, AP2, Circle, and custom escrow flows may
+  all coexist, forcing agents to support multiple challenge, credential,
+  receipt, and refund formats.
+- **Security risk:** paid retry flows create replay, resource-binding, metadata
+  leakage, and facilitator trust questions. The cleaner the one-line
+  integration, the easier it is to hide edge cases.
+- **Dispute risk:** low-value API calls can be final and simple; autonomous
+  commerce needs receipts, mandate constraints, refund logic, and merchant
+  accountability.
+- **Economic risk:** sub-cent payments only work when signature verification,
+  settlement, support, and accounting overhead are also sub-cent. Circle's
+  batching model is promising but product-specific.
+- **Adoption risk:** standards are only useful if agent frameworks, wallets,
+  merchants, MCP servers, and facilitators implement them consistently.
+- **Regulatory risk:** card, stablecoin, wallet, and merchant-processing flows
+  have different compliance obligations. "Agent paid" does not remove the need
+  to know who is the customer, merchant, and liable counterparty.
 
 ## References
-- Coinbase Developer Documentation, "Welcome to x402," https://docs.cdp.coinbase.com/x402/welcome, accessed 2026-06-05.
-- Stripe Documentation, "Machine payments," https://docs.stripe.com/payments/machine, accessed 2026-06-05.
-- Circle Developer Docs, "Agent Nanopayments," https://developers.circle.com/agent-stack/agent-nanopayments, accessed 2026-06-05.
-- AP2 Documentation, "Overview," https://ap2-protocol.org/overview/, accessed 2026-06-05.
-- kcolbchain, "switchboard," https://github.com/kcolbchain/switchboard, accessed 2026-06-05.
+
+- AP2 Protocol. "Agentic Payment Protocol (v0.2)." 2025. https://ap2-protocol.org/ap2/specification/. Accessed 2026-06-06.
+- AP2 Protocol. "Flows." 2025. https://ap2-protocol.org/ap2/flows/. Accessed 2026-06-06.
+- Circle. "Nanopayments." 2026. https://developers.circle.com/gateway/nanopayments. Accessed 2026-06-06.
+- Circle. "Circle Nanopayments Launches on Testnet as the Core Primitive for Agentic Economic Activity." 2026-03-10. https://www.circle.com/blog/circle-nanopayments-launches-on-testnet-as-the-core-primitive-for-agentic-economic-activity. Accessed 2026-06-06.
+- Coinbase Developer Platform. "x402 Overview." https://docs.cdp.coinbase.com/x402/welcome. Accessed 2026-06-06.
+- kcolbchain/switchboard. "README." commit ee67c1b5860f85ebb4d52f157fa21345387fde14. https://github.com/kcolbchain/switchboard.
+- Machine Payments Protocol. "MPP - Machine Payments Protocol." https://mpp.dev/. Accessed 2026-06-06.
+- Machine Payments Protocol. "Machine Payments Protocol Specifications." https://paymentauth.org/. Accessed 2026-06-06.
+- Machine Payments Protocol. "Payment hooks." 2026-05-21. https://mpp.dev/blog/payment-hooks. Accessed 2026-06-06.
+- Machine Payments Protocol. "Subscriptions." 2026-05-12. https://mpp.dev/blog/subscriptions. Accessed 2026-06-06.
+- x402 Foundation / Coinbase. "x402 README." https://github.com/coinbase/x402. Accessed 2026-06-06.
+- x402.org. "Payment Required - Internet-Native Payments Standard." https://www.x402.org/. Accessed 2026-06-06.


### PR DESCRIPTION
Closes #21

Summary:
- Add a new brief covering x402, MPP, AP2, Circle Nanopayments, and kcolbchain Switchboard.
- Include a comparison table for gas cost, latency, chain support, and maturity.
- Add inline citations and a References section with primary/official sources.
- Link the new brief from the README research brief table.

Verification:
- Word count: 2133 words, within the requested 1500-2500 range.
- Checked Markdown structure against briefs/_TEMPLATE.md sections.
- Ran git diff --cached --check before commit.