### PR TITLE
Add brief for Arbitrum CLI Clippy cleanup

### DIFF
--- a/briefs/arbitrum-cli-clippy-cleanup.md
+++ b/briefs/arbitrum-cli-clippy-cleanup.md
@@ -1,0 +1,54 @@
+# Keeping Arbitrum CLI Maintenance Changes Small and Auditable
+
+## Abstract
+
+This brief describes the approach used in `kcolbchain/arbitrum-cli#20` to resolve a small Rust Clippy cleanup without changing command behavior. The method was intentionally conservative: remove an unused import suppression, modernize formatting macros, extract one repeated address-normalization step, and simplify a test assertion so the code expressed the same intent with fewer lint triggers. The main finding is that low-risk maintenance work in blockchain command-line tools benefits from a narrow patch shape: changes should be mechanical, reviewable by diff, and separated from feature work. This keeps agent-assisted contributions easier to audit because maintainers can verify that no dependencies, external calls, credential paths, or protocol semantics changed. The same pattern applies broadly to protocol tooling where developer ergonomics matter but silent behavioral drift is unacceptable.
+
+## Context
+
+Blockchain CLIs sit near operational workflows: they prepare calls, inspect balances, format identifiers, and expose protocol primitives to developers. Even when a change is "only lint cleanup," it can touch code paths that build RPC requests or display transaction-related data. The safe default is therefore to keep maintenance PRs scoped to expression-level cleanup unless the issue explicitly asks for functional changes.
+
+The merged PR addressed `L0: Fix all cargo clippy warnings` in `kcolbchain/arbitrum-cli#19` and was merged as `kcolbchain/arbitrum-cli#20` ([GitHub PR, accessed 2026-06-06](https://github.com/kcolbchain/arbitrum-cli/pull/20)). Rust Clippy is the standard Rust lint collection for catching common mistakes and improving idiomatic code ([Rust Clippy documentation, accessed 2026-06-06](https://doc.rust-lang.org/clippy/)). Because the repository is a CLI rather than a library API, the practical review question was not only "does it compile?" but also "can a reviewer see that command outputs and RPC behavior remain the same?"
+
+## Key Findings
+
+- Small lint PRs should avoid mixed concerns. The patch kept the change set to unused imports/bindings, formatting idioms, and a localized variable extraction.
+- Formatting modernizations are safer when they preserve the same data boundaries. Updating `format!` and `eyre!` calls changed expression style, not the values being formatted.
+- Security review is faster when the diff has no new dependencies, no new network paths, and no token or environment-variable handling.
+
+## Analysis
+
+## Design Decisions
+
+The first decision was to remove the unused import workaround instead of keeping a suppressing binding. A suppression can make the compiler quiet, but it also leaves future readers wondering whether the symbol has hidden runtime significance. Removing the unused import made the file easier to scan and reduced the chance of stale helper references accumulating.
+
+The second decision was to modernize Rust formatting macros mechanically. For example, moving from positional interpolation to inline named capture is an idiomatic Rust cleanup, but it should still be treated as a maintenance edit. The review strategy was to keep each formatting change local: the same value is formatted, the same error path is used, and the surrounding control flow is untouched.
+
+The third decision was to extract a trimmed address variable in one balance path. This was the only cleanup that introduced a new local binding, and it was intentionally narrow. The goal was to make repeated address normalization explicit while preserving the downstream call shape. In protocol tooling, that is preferable to broad helper extraction when the issue is only about Clippy warnings.
+
+## Security Considerations
+
+The most important security choice was negative space: the PR did not add dependencies, file IO, environment-variable reads, subprocess calls, or external network endpoints. It also avoided touching private-key handling, transaction signing, RPC provider selection, and ABI selector logic beyond removing an unused reference.
+
+The output-related edits were reviewed as display-only changes. Formatting transaction hashes, numeric identifiers, and user-facing text is not usually a cryptographic risk by itself, but display regressions can still mislead operators. Keeping these edits mechanical made it easier to compare before and after behavior by inspection.
+
+The test assertion cleanup followed the same principle. Replacing an allocation-heavy `contains(&"agent-deposit".to_string())` style assertion with an iterator comparison expresses the same test intent without introducing broader test rewrites. That matters because tests should not become a second source of behavior changes in a lint-only PR.
+
+## Fit in the Broader Ecosystem
+
+Agent-assisted maintenance works best when it produces patches that maintainers can review quickly. In blockchain repositories, this is especially important because tool changes may sit close to signing, transaction construction, chain selection, or RPC usage. A small Clippy cleanup is valuable when it reduces friction for future contributors without asking reviewers to re-evaluate protocol assumptions.
+
+This contribution also illustrates a useful onboarding path. Lint and formatting issues are good first contributions when they are scoped carefully: the contributor learns the repository layout, maintainers get a cleaner baseline, and future feature work starts from code with fewer distractions. The tradeoff is that the contributor must resist the urge to bundle refactors, new abstractions, or speculative improvements into the same PR.
+
+## Risks and Open Questions
+
+- The local environment used for the original PR did not include Rust/Cargo, so verification relied on raw-file comparison rather than running `cargo clippy` locally.
+- Formatting changes should still be validated by CI because macro syntax can be compiler-version sensitive.
+- Future lint tasks could be safer if repositories publish a minimal maintenance checklist that identifies command-output snapshots, signing paths, and RPC paths that should not change during cleanup PRs.
+
+## References
+
+- kcolbchain, "fix: clean up clippy warnings," Pull Request #20, 2026, https://github.com/kcolbchain/arbitrum-cli/pull/20, accessed 2026-06-06.
+- kcolbchain, "L0: Fix all cargo clippy warnings," Issue #19, 2026, https://github.com/kcolbchain/arbitrum-cli/issues/19, accessed 2026-06-06.
+- Rust Project, "Clippy Documentation," https://doc.rust-lang.org/clippy/, accessed 2026-06-06.
+- kcolbchain, "Contributing to research," https://github.com/kcolbchain/research/blob/main/CONTRIBUTING.md, accessed 2026-06-06.


### PR DESCRIPTION
## Summary
- Add a contributor technical brief for kcolbchain/arbitrum-cli#20
- Describe the maintenance strategy used for the Clippy cleanup
- Cover design decisions, security considerations, ecosystem fit, risks, and references

## Context
This follows the maintainer invitation on kcolbchain/arbitrum-cli#20 to write a short technical brief about the approach.

## Verification
- Checked the brief against briefs/_TEMPLATE.md sections
- Confirmed abstract length is 123 words
- Saved the file locally and uploaded it via the GitHub API